### PR TITLE
fix(sidebar): remove duplicate Albums label in sidebar

### DIFF
--- a/data/data.js
+++ b/data/data.js
@@ -30,10 +30,6 @@ export const links = [
         icon: <VolumeDownIcon />,
       },
       {
-        name: 'Albums',
-        icon: <StopCircleIcon />,
-      },
-      {
         name: 'Artists',
         icon: <MicIcon />,
       },


### PR DESCRIPTION
Fix duplicate **Albums** label in sidebar.

Decided to remove label under **Menu** in order to have equal 4 sub-menu each.

Screenshot:

![image](https://user-images.githubusercontent.com/64537418/194604444-48c45cab-5033-414e-9c0f-7054a0d56280.png)
