### PR TITLE
Fix NaN duration - #115

### DIFF
--- a/components/Player/Player.jsx
+++ b/components/Player/Player.jsx
@@ -23,7 +23,7 @@ const Player = () => {
     let key;
 
     key = setInterval(() => {
-      setDuration(audio?.duration);
+      audio.duration && setDuration(audio.duration);
       setCurrentTime(audio?.currentTime);
       setProgressTime((audio?.currentTime / audio?.duration) * 100);
     }, 1000);


### PR DESCRIPTION
The duration state is set with the NaN value. I prevent that to fix it. #115 